### PR TITLE
remove useless null initialization

### DIFF
--- a/src/FilamentManager.php
+++ b/src/FilamentManager.php
@@ -455,8 +455,6 @@ class FilamentManager
 
     public function getUserAvatarUrl(Model | Authenticatable $user): string
     {
-        $avatar = null;
-
         if ($user instanceof HasAvatar) {
             $avatar = $user->getFilamentAvatarUrl();
         } else {


### PR DESCRIPTION
The `$avatar = null;` is meaningless, due to `if ... else` condition.